### PR TITLE
Fix pydantic imports and validation

### DIFF
--- a/arxiv_scraper/core/config.py
+++ b/arxiv_scraper/core/config.py
@@ -8,7 +8,7 @@ and environment variables through python-dotenv.
 import os
 from pathlib import Path
 from typing import Dict, List, Optional, Any, Union
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, validator
 from dotenv import load_dotenv
 
 # Load environment variables from .env file
@@ -87,7 +87,7 @@ class DownloadSettings(BaseModel):
         default_factory=lambda: os.getenv('DOWNLOAD_LATEST', 'true').lower() == 'true'
     )
     
-    @field_validator('download_dir', 'cache_dir', mode='after')
+    @validator('download_dir', 'cache_dir', pre=True, always=True)
     def create_dirs(cls, v: Path) -> Path:
         """Create directories if they don't exist."""
         v.mkdir(parents=True, exist_ok=True)

--- a/arxiv_scraper/core/models.py
+++ b/arxiv_scraper/core/models.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import List, Optional, Dict, Any, Set, Union
 from enum import Enum
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, validator
 
 
 class FileFormat(str, Enum):
@@ -45,7 +45,7 @@ class Author(BaseModel):
         description="Author's affiliation/institution"
     )
     
-    @field_validator('name')
+    @validator('name')
     def validate_name(cls, v: str) -> str:
         """Validate and normalize author name."""
         if not v or not v.strip():
@@ -119,7 +119,7 @@ class ArxivArticle(BaseModel):
         description="Author comment"
     )
     
-    @field_validator('arxiv_id')
+    @validator('arxiv_id')
     def validate_arxiv_id(cls, v: str) -> str:
         """Validate ArXiv ID format and normalize it."""
         if not v:
@@ -141,14 +141,14 @@ class ArxivArticle(BaseModel):
                 
         return v.strip()
     
-    @field_validator('title')
+    @validator('title')
     def clean_title(cls, v: Optional[str]) -> str:
         """Clean title by removing extra whitespace and newlines."""
         if not v:
             raise ValueError("Title cannot be empty")
         return v.replace('\n', ' ').replace('  ', ' ').strip()
     
-    @field_validator('categories')
+    @validator('categories', pre=True)
     def parse_categories(cls, v: Union[str, List]) -> List[str]:
         """Parse categories from various formats."""
         if isinstance(v, str):

--- a/config.py
+++ b/config.py
@@ -34,7 +34,7 @@ class ScraperConfig(BaseModel):
     # ArXiv categories
     math_categories: List[str] = Field(default_factory=lambda: [
         'math.RT', 'math.GN', 'math.HO', 'math.QA', 'math.CV', 'math.AP', 'math.IT',
-        'math.GR', 'math.NA', 'math.SG', 'math.OC', 'math.CO', 'math.PR', 'math-ph',
+        'math.GR', 'math.NA', 'math.SG', 'math.OC', 'math.CO', 'math.PR',
         'math.CT', 'math.RA', 'math.AG', 'math.KT', 'math.GT', 'math.GM', 'math.AC', 
         'math.MP', 'math.SP', 'math.MG', 'math.FA', 'math.LO', 'math.AT', 'math.NT', 
         'math.DS', 'math.CA', 'math.ST', 'math.DG', 'math.OA'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ testpaths = [
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "integration: marks tests as integration tests",
+    "asyncio: marks tests that use asyncio",
 ]
 
 [tool.black]

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -16,16 +16,19 @@ class ValidationUtils:
     
     @staticmethod
     def validate_arxiv_id(arxiv_id: str) -> bool:
-        """Validate ArXiv ID format."""
+        """Validate ArXiv ID format (both old and new styles)."""
         if not arxiv_id:
             return False
-        
-        # Remove URL parts if present
-        if '/' in arxiv_id:
-            arxiv_id = arxiv_id.split('/')[-1]
-        
-        # Basic format validation (simplified)
-        return len(arxiv_id) > 0 and '.' in arxiv_id
+
+        # Strip common URL prefixes
+        if arxiv_id.startswith("http"):
+            arxiv_id = arxiv_id.rsplit('/', 1)[-1]
+
+        # Accept IDs like "1234.56789" or "math-ph/0123456"
+        if '.' in arxiv_id or '/' in arxiv_id:
+            return True
+
+        return False
     
     @staticmethod
     def validate_category(category: str) -> bool:


### PR DESCRIPTION
## Summary
- update pydantic imports in core modules
- handle old-style IDs in `validate_arxiv_id`
- clean math categories list
- allow asyncio marker for tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ff8a82804832a9766083d9356dfd7