### PR TITLE
Add CLI subcommand to run GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,10 +130,13 @@ docker-compose up
 ### GUI Application
 
 The project also includes a PyQt6-based graphical interface that exposes all CLI
-features. After installing the package with GUI dependencies, launch it with:
+features. After installing the package with GUI dependencies, launch it with
+either the dedicated command or the new subcommand:
 
 ```bash
 arxiv-scraper-gui
+# or
+arxiv-scraper gui
 ```
 
 The GUI allows you to run scrape, search and other commands through an easy-to-

--- a/arxiv_scraper/cli/main.py
+++ b/arxiv_scraper/cli/main.py
@@ -551,6 +551,14 @@ async def _cache(days: int):
                 logger.success(f"Cleared all {cleared} cache entries")
 
 
+@cli.command()
+def gui():
+    """Launch the graphical user interface."""
+    from arxiv_scraper.gui.main import main as gui_main
+
+    gui_main()
+
+
 def main():
     """Main entry point."""
     try:


### PR DESCRIPTION
## Summary
- add a `gui` command to the CLI
- mention the command in the README

## Testing
- `pytest -q`
- `ruff check .` *(fails: Failed to parse pyproject.toml)*

------
https://chatgpt.com/codex/tasks/task_e_684023652c50832abbe037550619c7b9