### PR TITLE
Add script to launch GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,13 @@ arxiv-scraper-gui
 arxiv-scraper gui
 ```
 
+If you cloned the repository and prefer not to install the package, you can
+also start the GUI directly:
+
+```bash
+python start_gui.py
+```
+
 The GUI allows you to run scrape, search and other commands through an easy-to-
 use interface and view the log output directly in the window.
 

--- a/start_gui.py
+++ b/start_gui.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+"""Launch the ArXiv Scraper graphical interface."""
+
+from arxiv_scraper.gui.main import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `start_gui.py` helper script for launching the PyQt GUI without installing the package
- document using this script in the README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684040bc38f8832a8cd7b5ce485f0e09